### PR TITLE
Enable BE search

### DIFF
--- a/Configuration/TCA/tx_mediaoembed_provider.php
+++ b/Configuration/TCA/tx_mediaoembed_provider.php
@@ -20,6 +20,7 @@ return array(
 		),
 		'title' => $languagePrefix . 'tx_mediaoembed_provider',
 		'iconfile'  => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('mediaoembed') . 'Resources/Public/Icons/table_provider.png',
+		'searchFields' => 'name,description,url_schemes'
 	),
 
 	'interface' => array(


### PR DESCRIPTION
For records to be searchable in the BE, the table must have the
"searchFields" property defined. This patch adds it to
tx_mediaoembed_provider.
